### PR TITLE
Changed "extend" loop by adding hasOwnProperty()

### DIFF
--- a/magiceye.js
+++ b/magiceye.js
@@ -25,7 +25,7 @@
       };
 
       for (var property in defaultOptions) {
-        opts[property] = (opts && opts[property]) ? opts[property] : defaultOptions[property];
+        if( ! opts.hasOwnProperty(property) ) opts[property] = defaultOptions[property];
       }
 
       var element, width, height, depthMap, pixelData, i;


### PR DESCRIPTION
Changed the ternary operator to a simple `if()` w/ `Object.prototype.hasOwnProperty()` because
- the condition `opts` was always `true` and thus unnecessary
- `opts[property]` also will do a scope chain lookup and can cause trouble when using `true` or `false` as a value.

Some infos:
[http://andrew.hedges.name/experiments/in/](http://andrew.hedges.name/experiments/in/)
[Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty)
[underscore.js annotated source code | Section 85](http://underscorejs.org/docs/underscore.html#section-85)
