### PR TITLE
Add bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "magic-eye",
+  "main": ["magiceye.min.js", "depthmappers/*.js"],
+  "version": "0.2.0",
+  "homepage": "https://github.com/peeinears/MagicEye.js",
+  "authors": [
+    "Ian Pearce <ian@ianpearce.com> (https://github.com/peeinears)"
+  ],
+  "description": "A JavaScript library for generating single image random dot stereograms (\"Magic Eye\") in the browser",
+  "keywords": [
+    "magiceye",
+    "image",
+    "stereogram"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "Gruntfile.js",
+    "package.json",
+    "examples"
+  ]
+}


### PR DESCRIPTION
PR to add a `bower.json` file to the repo. 

The only thing I am unsure about is having `"depthmappers/*.js"` in main array. It's useful when wanting to experiment with the different depthmappers. Using it in production could mean that unnecessary files are loaded by the client. On the other hand developers have a number of ways to strip out the files if that is what they want like a local override in their own bower file to strip out the depthmappers they don't need. 
