### PR TITLE
Update ImgDepthMapper.js

### DIFF
--- a/depthmappers/ImgDepthMapper.js
+++ b/depthmappers/ImgDepthMapper.js
@@ -3,8 +3,9 @@
 //
 MagicEye.ImgDepthMapper = MagicEye.DepthMapper.extend({
 
-  constructor: function (img) {
+  constructor: function (img, invert) {
     this.img = img;
+    this.invert = invert;
   },
 
   make: function () {
@@ -30,7 +31,10 @@ MagicEye.ImgDepthMapper = MagicEye.DepthMapper.extend({
       offset = width * y * 4;
       for (x = 0; x < width; x++) {
         // assume grayscale (R, G, and B are equal)
-        depthMap[y][x] = pixelData[offset + (x * 4)];
+        depthMap[y][x] = pixelData[offset + (x * 4)]/255;
+        if (this.invert === true) {
+          depthMap[y][x] = 1 - depthMap[y][x];
+        }
       }
     }
     return depthMap;


### PR DESCRIPTION
"pixelData" array off a canvas gives grayscale values from 0-255, not 0.0-1.0, so factor them down, to properly parse normal grayscale images.

Also added the option to indicate this depth map is reversed (black is closest)
