### PR TITLE
Fix error in JPG to Magic Eye example

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <meta content="width=device-width, initial-scale=1" name="viewport" />
   <meta content="MagicEye.js is a JavaScript library for generating \"Magic Eye\" images (single image random dot stereograms, or SIRDS) in the browser." name="description" />
   <meta content="Magic Eye, MagicEye, javascript, js, magiceye.js, stereogram, autostereogram, SIRDS" name="keywords" />
-  <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700italic,700' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700italic,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
   <link href="assets/styles.css" media="all" rel="stylesheet" type="text/css" />
 </head>
 <body>

--- a/jpg-to-magiceye.html
+++ b/jpg-to-magiceye.html
@@ -6,8 +6,8 @@
   <meta content="width=device-width, initial-scale=1" name="viewport" />
   <meta content="MagicEye.js is a JavaScript library for generating \"Magic Eye\" images (single image random dot stereograms, or SIRDS) in the browser." name="description" />
   <meta content="Magic Eye, MagicEye, javascript, js, magiceye.js, stereogram, autostereogram, SIRDS" name="keywords" />
-  <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700italic,700' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700italic,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
   <link href="assets/styles.css" media="all" rel="stylesheet" type="text/css" />
   <style>
     #file-input {
@@ -76,7 +76,7 @@
 
   <script type="text/javascript" src="magiceye.js"></script>
   <script type="text/javascript" src="depthmappers/CanvasDepthMapper.js"></script>
-  <script type="text/javascript" src="http://notmasteryet.github.io/jpgjs/jpg.js"></script>
+  <script type="text/javascript" src="https://notmasteryet.github.io/jpgjs/jpg.js"></script>
 
   <script>
     (function() {

--- a/text-to-magiceye.html
+++ b/text-to-magiceye.html
@@ -6,8 +6,8 @@
   <meta content="width=device-width, initial-scale=1" name="viewport" />
   <meta content="MagicEye.js is a JavaScript library for generating \"Magic Eye\" images (single image random dot stereograms, or SIRDS) in the browser." name="description" />
   <meta content="Magic Eye, MagicEye, javascript, js, magiceye.js, stereogram, autostereogram, SIRDS" name="keywords" />
-  <link href='http://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700italic,700' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700italic,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=PT+Serif' rel='stylesheet' type='text/css'>
   <link href="assets/styles.css" media="all" rel="stylesheet" type="text/css" />
   <style>
     #magic-eye {


### PR DESCRIPTION
Switch src for jpg.js to https to prevent Mixed Content errors and allow the script to load. Additionally change the Google Fonts stylesheet URLs for the same issue.

![image](https://cloud.githubusercontent.com/assets/97460/20807758/312798be-b7ce-11e6-9168-e58c092d36d9.png)
